### PR TITLE
Generate `index.cjs.native.js` to help React Native resolve `index.cjs`

### DIFF
--- a/index.cjs.native.js
+++ b/index.cjs.native.js
@@ -1,0 +1,1 @@
+exports.Observable = require("zen-observable/index.js");

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import { promises as fs } from "fs";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import babel from "@rollup/plugin-babel";
 
@@ -19,16 +20,25 @@ const babelPlugins = zenBabelPlugins
 export default [
   {
     input: ["./src/module.js"],
+    output: {
+      file: "module.js",
+      format: "esm",
+    },
     plugins: [
       nodeResolve(),
       babel({
         plugins: babelPlugins,
         babelHelpers: "inline",
       }),
+      {
+        name: "copy index.cjs to index.cjs.native.js",
+        async writeBundle() {
+          await fs.writeFile(
+            "index.cjs.native.js",
+            await fs.readFile("index.cjs"),
+          );
+        },
+      },
     ],
-    output: {
-      file: "module.js",
-      format: "esm",
-    },
   },
 ];


### PR DESCRIPTION
Should help with https://github.com/apollographql/apollo-client/issues/9437, since React Native also complains about `.cjs` files in dependencies of `@apollo/client`, and `zen-observable-ts` (this package) is a dependency of `@apollo/client`.